### PR TITLE
Add support for basic SSO via Trusted Header Auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
-*.sqlite3
+*~
 *.db
+*.bak
+*.sqlite3
+**/.DS_Store
+
+/phoenix

--- a/config/main.go
+++ b/config/main.go
@@ -12,6 +12,7 @@ type Config struct {
 	LogLevel        string `default:"warning"`
 	EnableGinLogger bool   `default:"false"`
 	Production      bool   `default:"true"`
+	HeaderAuth      bool   `default:"false"`
 	DefaultUsername string
 	DefaultPassword string
 }

--- a/readme.md
+++ b/readme.md
@@ -8,6 +8,7 @@ Self-hosted start page without the extra stuff.
 - No javascript
 - Relatively low resource consumption (around 7 MiB of RAM)
 - Authorization support
+  - SSO via Trusted Header Auth (_Reverse Proxy_)
 
 ## Configuration
 Service settings can be set through environment variables.
@@ -19,6 +20,7 @@ Service settings can be set through environment variables.
 | P_LOGLEVEL          | Log level settings: `debug`, `info`, `warning`, `error`, `fatal` | `warning`                             |
 | P_ENABLEGINLOGGER   | Enable gin's logging middleware. Can create a lot of logs.       | `false`                               |
 | P_PRODUCTION        | Is this instance running in production mode?                     | `true`                                |
+| P_HEADERAUTH        | Enable Trusted Header Auth (SSO)                                 | `false`                               |
 | P_DEFAULTUSERNAME   | Data for the first user.                                         |                                       |
 | P_DEFAULTPASSWORD   | Data for the first user.                                         |                                       |
 

--- a/views/auth.go
+++ b/views/auth.go
@@ -78,15 +78,16 @@ func AuthMiddleware(c *gin.Context, db *gorm.DB, cfg *config.Config) {
 				return
 			}
 			SetTokenCookie(c, token)
-		} else {
-			if database.CountAdmins(db) < 1 {
-				c.Redirect(http.StatusFound, "/registration")
-			} else {
-				c.Redirect(http.StatusFound, "/signin")
-			}
-			c.Abort()
 			return
 		}
+
+		if database.CountAdmins(db) < 1 {
+			c.Redirect(http.StatusFound, "/registration")
+		} else {
+			c.Redirect(http.StatusFound, "/signin")
+		}
+		c.Abort()
+		return
 	}
 
 	// Create a new token if the old one is about to expire


### PR DESCRIPTION
See #39 -- This basically implements (_testing it on my instance now_) basic SSO via Trusted Header Auth with Authelia in front.